### PR TITLE
Removing preceding '$' from code blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,37 +36,37 @@ Shipwright supports any tool that can build container images in Kubernetes clust
 * We also require a Tekton installation (v0.19+). To install the latest version, run:
 
   ```bash
-  $ kubectl apply --filename https://storage.googleapis.com/tekton-releases/pipeline/previous/v0.20.1/release.yaml
+  kubectl apply --filename https://storage.googleapis.com/tekton-releases/pipeline/previous/v0.20.1/release.yaml
   ```
 
 * Install the Shipwright deployment. To install the latest version, run:
 
   ```bash
-  $ kubectl apply --filename https://github.com/shipwright-io/build/releases/download/nightly/nightly-2021-03-24-1616591545.yaml
+  kubectl apply --filename https://github.com/shipwright-io/build/releases/download/nightly/nightly-2021-03-24-1616591545.yaml
   ```
 
 * Install the Shipwright strategies. To install the latest version, run:
 
   ```bash
-  $ kubectl apply --filename https://github.com/shipwright-io/build/releases/download/nightly/default_strategies.yaml
+  kubectl apply --filename https://github.com/shipwright-io/build/releases/download/nightly/default_strategies.yaml
   ```
 
 * Generate a secret to access your container registry, such as one on [Docker Hub](https://hub.docker.com/) or [Quay.io](https://quay.io/):
 
   ```bash
-  $ REGISTRY_SERVER=https://index.docker.io/v1/ REGISTRY_USER=<your_registry_user> REGISTRY_PASSWORD=<your_registry_password>
-  $ kubectl create secret docker-registry push-secret \
+  REGISTRY_SERVER=https://index.docker.io/v1/ REGISTRY_USER=<your_registry_user> REGISTRY_PASSWORD=<your_registry_password>
+  kubectl create secret docker-registry push-secret \
       --docker-server=$REGISTRY_SERVER \
       --docker-username=$REGISTRY_USER \
       --docker-password=$REGISTRY_PASSWORD  \
-      --docker-email=me@here.com
+      --docker-email=<your_email>
   ```
 
 * Create a Build object, replacing `<REGISTRY_ORG>` with the registry username your `push-secret` secret have access to:
 
   ```bash
-  $ REGISTRY_ORG=<your_registry_org>
-  $ cat <<EOF | kubectl apply -f -
+  REGISTRY_ORG=<your_registry_org>
+  cat <<EOF | kubectl apply -f -
   apiVersion: shipwright.io/v1alpha1
   kind: Build
   metadata:
@@ -86,15 +86,18 @@ Shipwright supports any tool that can build container images in Kubernetes clust
   ```
 
   ```bash
-  $ kubectl get builds
+  kubectl get builds
+  ```
+The output will be something like:
+
+  ```
   NAME                     REGISTERED   REASON      BUILDSTRATEGYKIND      BUILDSTRATEGYNAME   CREATIONTIME
   buildpack-nodejs-build   True         Succeeded   ClusterBuildStrategy   buildpacks-v3       68s
-  ```
-
+  ```  
 * Submit your buildrun:
 
   ```bash
-  $ cat <<EOF | kubectl create -f -
+  cat <<EOF | kubectl create -f -
   apiVersion: shipwright.io/v1alpha1
   kind: BuildRun
   metadata:
@@ -108,7 +111,10 @@ Shipwright supports any tool that can build container images in Kubernetes clust
 * Wait until your buildrun is completed:
 
   ```bash
-  $ kubectl get buildruns
+  kubectl get buildruns
+  ```
+
+  ```
   NAME                              SUCCEEDED   REASON      STARTTIME   COMPLETIONTIME
   buildpack-nodejs-buildrun-xyzds   True        Succeeded   69s         2s
   ```


### PR DESCRIPTION
When a user tries to copy a code block using the "copy" button, the preceding '$' gets copied too and defeats the purpose of the shortcut button. Hence proposing the removal of the preceding '$' from code blocks.

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

<!-- If this PR fixes a GitHub issue, please mention it like so:

Fixes #<insert issue number here>

-->

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [x] Includes docs if changes are user-facing
- [ ] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [ ] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
